### PR TITLE
Make it send

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,12 +10,15 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-
+  ci:
+    name: CI
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        components: clippy, rustfmt
 
     - name: Install alsa and udev
       run: sudo apt-get update -yq; sudo apt-get install -yq --no-install-recommends libasound2-dev libudev-dev
@@ -26,8 +29,8 @@ jobs:
     - name: fmt
       run: cargo fmt --all -- --check
 
-    - name: check
-      run: cargo check
+    - name: build
+      run: cargo build
 
     - name: clippy
       run: cargo clippy -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { git = "https://github.com/zaclegarssure/bevy", branch = "nonsend_scope", features = ["dynamic_linking"] }
+bevy = { version = "0.11.0", features = ["dynamic_linking"] }
 pin-project = "1"
 
 [profile.dev]

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -6,13 +6,13 @@ use corentin::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .insert_non_send_resource(Executor::new())
+        .insert_resource(Executor::new())
         .add_systems(Startup, setup_coroutines)
         .add_systems(Update, run_coroutines)
         .run();
 }
 
-fn setup_coroutines(mut executor: NonSendMut<Executor>) {
+fn setup_coroutines(mut executor: ResMut<Executor>) {
     executor.add(|mut fib| async move {
         let mut i = 0;
         loop {
@@ -24,7 +24,7 @@ fn setup_coroutines(mut executor: NonSendMut<Executor>) {
 }
 
 fn run_coroutines(world: &mut World) {
-    world.non_send_resource_scope(|w, mut exec: Mut<Executor>| {
+    world.resource_scope(|w, mut exec: Mut<Executor>| {
         exec.run(w);
     })
 }

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -11,10 +11,11 @@ use waker::create;
 
 use crate::{coroutine, waker};
 
-pub(crate) type CoroObject = Pin<Box<dyn Future<Output = ()>>>;
+pub(crate) type CoroObject = Pin<Box<dyn Future<Output = ()> + Send + Sync>>;
 
 type CoroId = Entity;
 
+#[derive(Resource)]
 pub struct Executor {
     coroutines: HashMap<Entity, CoroObject>,
     receiver: Rc<Cell<Option<WaitingReason>>>,
@@ -28,6 +29,11 @@ pub struct Executor {
     is_awaited_by: HashMap<CoroId, CoroId>,
     own: HashMap<Entity, Vec<CoroId>>,
 }
+
+// SAFETY: This is safe because the only !Send and !Sync field (receiver) is only accessed
+// when calling run(), which is done in a single threaded context.
+unsafe impl Send for Executor {}
+unsafe impl Sync for Executor {}
 
 const ERR_WRONGAWAIT: &'static str = "A coroutine yielded without notifying the executor
 the reason. That is most likely because it awaits a
@@ -54,7 +60,7 @@ impl Executor {
     /// Add a coroutine to the executor.
     pub fn add<C, F>(&mut self, closure: C)
     where
-        F: Future<Output = ()> + 'static,
+        F: Future<Output = ()> + 'static + Send + Sync,
         C: FnOnce(Fib) -> F,
     {
         let fib = Fib {
@@ -69,7 +75,7 @@ impl Executor {
     /// If the entity is removed, the coroutine is dropped.
     pub fn add_to_entity<C, F>(&mut self, entity: Entity, closure: C)
     where
-        F: Future<Output = ()> + 'static,
+        F: Future<Output = ()> + 'static + Send + Sync,
         C: FnOnce(Fib, Entity) -> F,
     {
         let fib = Fib {
@@ -273,9 +279,9 @@ mod tests {
     #[test]
     fn par_or_despawn_correctly() {
         let mut world = World::new();
-        world.insert_non_send_resource(Executor::new());
+        world.insert_resource(Executor::new());
         world.insert_resource(Time::new(Instant::now()));
-        world.non_send_resource_scope(|w, mut executor: Mut<Executor>| {
+        world.resource_scope(|w, mut executor: Mut<Executor>| {
             executor.add(move |mut fib| async move {
                 fib.par_or(|mut fib| async move {
                     loop {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,22 +1,24 @@
 //! A coroutine library for the [bevy](https://github.com/bevyengine/bevy) game engine.
 //!
 //! TODO: Show example
-pub mod executor;
 pub mod coroutine;
+pub mod executor;
 
 mod waker;
 
 pub mod prelude {
     #[doc(hidden)]
-    pub use crate::executor::Executor;
-    #[doc(hidden)]
     pub use crate::coroutine::Fib;
+    #[doc(hidden)]
+    pub use crate::executor::Executor;
 }
-
 
 #[cfg(test)]
 mod tests {
-    use std::{cell::RefCell, rc::Rc, time::Instant};
+    use std::{
+        sync::{Arc, Mutex},
+        time::Instant,
+    };
 
     use bevy::{
         prelude::{Component, Mut, World},
@@ -31,26 +33,26 @@ mod tests {
     #[test]
     fn wait_on_tick() {
         let mut world = World::new();
-        world.insert_non_send_resource(Executor::new());
+        world.insert_resource(Executor::new());
         world.insert_resource(Time::new(Instant::now()));
-        world.non_send_resource_scope(|w, mut executor: Mut<Executor>| {
-            let a = Rc::new(RefCell::new(0));
-            let b = Rc::clone(&a);
+        world.resource_scope(|w, mut executor: Mut<Executor>| {
+            let a = Arc::new(Mutex::new(0));
+            let b = Arc::clone(&a);
             executor.add(move |mut fib| async move {
-                *b.borrow_mut() += 1;
+                *b.lock().unwrap() += 1;
                 fib.next_tick().await;
-                *b.borrow_mut() += 1;
+                *b.lock().unwrap() += 1;
                 fib.next_tick().await;
-                *b.borrow_mut() += 1;
+                *b.lock().unwrap() += 1;
             });
             executor.run(w);
-            assert_eq!(*a.borrow(), 1);
+            assert_eq!(*a.lock().unwrap(), 1);
             executor.run(w);
-            assert_eq!(*a.borrow(), 2);
+            assert_eq!(*a.lock().unwrap(), 2);
             executor.run(w);
-            assert_eq!(*a.borrow(), 3);
+            assert_eq!(*a.lock().unwrap(), 3);
             executor.run(w);
-            assert_eq!(*a.borrow(), 3);
+            assert_eq!(*a.lock().unwrap(), 3);
         });
     }
 
@@ -62,53 +64,53 @@ mod tests {
         }
 
         let mut world = World::new();
-        world.insert_non_send_resource(Executor::new());
+        world.insert_resource(Executor::new());
         world.insert_resource(Time::new(Instant::now()));
-        world.non_send_resource_scope(|w, mut executor: Mut<Executor>| {
-            let a = Rc::new(RefCell::new(0));
-            let b = Rc::clone(&a);
+        world.resource_scope(|w, mut executor: Mut<Executor>| {
+            let a = Arc::new(Mutex::new(0));
+            let b = Arc::clone(&a);
             executor.add(move |mut fib| async move {
-                *b.borrow_mut() += 1;
+                *b.lock().unwrap() += 1;
                 fib.on(sub_coro).await;
-                *b.borrow_mut() += 1;
+                *b.lock().unwrap() += 1;
             });
             executor.run(w);
-            assert_eq!(*a.borrow(), 1);
+            assert_eq!(*a.lock().unwrap(), 1);
             executor.run(w);
-            assert_eq!(*a.borrow(), 1);
+            assert_eq!(*a.lock().unwrap(), 1);
             executor.run(w);
-            assert_eq!(*a.borrow(), 2);
+            assert_eq!(*a.lock().unwrap(), 2);
             executor.run(w);
-            assert_eq!(*a.borrow(), 2);
+            assert_eq!(*a.lock().unwrap(), 2);
         });
     }
 
     #[test]
     fn wait_on_change() {
         let mut world = World::new();
-        world.insert_non_send_resource(Executor::new());
+        world.insert_resource(Executor::new());
         world.insert_resource(Time::new(Instant::now()));
-        world.non_send_resource_scope(|w, mut executor: Mut<Executor>| {
+        world.resource_scope(|w, mut executor: Mut<Executor>| {
             let e = w.spawn(ExampleComponent(0)).id();
-            let a = Rc::new(RefCell::new(0));
-            let b = Rc::clone(&a);
+            let a = Arc::new(Mutex::new(0));
+            let b = Arc::clone(&a);
             executor.add(move |mut fib| async move {
                 fib.next_tick().await;
                 fib.change::<ExampleComponent>(e).await;
-                *b.borrow_mut() += 1;
+                *b.lock().unwrap() += 1;
             });
             executor.run(w);
-            assert_eq!(*a.borrow(), 0);
+            assert_eq!(*a.lock().unwrap(), 0);
             w.clear_trackers();
             executor.run(w);
-            assert_eq!(*a.borrow(), 0);
+            assert_eq!(*a.lock().unwrap(), 0);
             executor.run(w);
-            assert_eq!(*a.borrow(), 0);
+            assert_eq!(*a.lock().unwrap(), 0);
             w.entity_mut(e).get_mut::<ExampleComponent>().unwrap().0 += 1;
             executor.run(w);
-            assert_eq!(*a.borrow(), 1);
+            assert_eq!(*a.lock().unwrap(), 1);
             executor.run(w);
-            assert_eq!(*a.borrow(), 1);
+            assert_eq!(*a.lock().unwrap(), 1);
         });
     }
 
@@ -119,9 +121,9 @@ mod tests {
             std::future::pending::<()>().await;
         }
         let mut world = World::new();
-        world.insert_non_send_resource(Executor::new());
+        world.insert_resource(Executor::new());
         world.insert_resource(Time::new(Instant::now()));
-        world.non_send_resource_scope(|w, mut executor: Mut<Executor>| {
+        world.resource_scope(|w, mut executor: Mut<Executor>| {
             executor.add(move |_| async move {
                 external_future().await;
             });
@@ -132,16 +134,16 @@ mod tests {
     #[test]
     fn waiting_on_par_or() {
         let mut world = World::new();
-        world.insert_non_send_resource(Executor::new());
+        world.insert_resource(Executor::new());
         world.insert_resource(Time::new(Instant::now()));
-        world.non_send_resource_scope(|w, mut executor: Mut<Executor>| {
-            let a = Rc::new(RefCell::new(0));
-            let b = Rc::clone(&a);
+        world.resource_scope(|w, mut executor: Mut<Executor>| {
+            let a = Arc::new(Mutex::new(0));
+            let b = Arc::clone(&a);
             executor.add(move |mut fib| async move {
                 fib.par_or(|mut fib| async move {
                     loop {
                         fib.next_tick().await;
-                        *b.borrow_mut() += 1;
+                        *b.lock().unwrap() += 1;
                     }
                 })
                 .with(|mut fib| async move {
@@ -154,46 +156,45 @@ mod tests {
 
             for i in 0..5 {
                 // Note that it works because the coroutine on the the top of the par_or,
-                // has priority over the one on the bottom, meaning its side effect will be 
+                // has priority over the one on the bottom, meaning its side effect will be
                 // seen on the last iteration.
                 executor.run(w);
-                assert_eq!(*a.borrow_mut(), i);
+                assert_eq!(*a.lock().unwrap(), i);
             }
         });
     }
 
-
     #[test]
     fn waiting_on_par_and() {
         let mut world = World::new();
-        world.insert_non_send_resource(Executor::new());
+        world.insert_resource(Executor::new());
         world.insert_resource(Time::new(Instant::now()));
-        world.non_send_resource_scope(|w, mut executor: Mut<Executor>| {
-            let a = Rc::new(RefCell::new(0));
-            let b = Rc::clone(&a);
-            let c = Rc::clone(&a);
+        world.resource_scope(|w, mut executor: Mut<Executor>| {
+            let a = Arc::new(Mutex::new(0));
+            let b = Arc::clone(&a);
+            let c = Arc::clone(&a);
             executor.add(move |mut fib| async move {
                 fib.par_and(|mut fib| async move {
                     fib.next_tick().await;
-                    *b.borrow_mut() += 1;
+                    *b.lock().unwrap() += 1;
                 })
                 .with(|mut fib| async move {
                     for _ in 0..2 {
                         fib.next_tick().await;
-                        *c.borrow_mut() += 1;
+                        *c.lock().unwrap() += 1;
                     }
                 })
                 .await;
             });
 
             executor.run(w);
-            assert_eq!(*a.borrow_mut(), 0);
+            assert_eq!(*a.lock().unwrap(), 0);
             executor.run(w);
-            assert_eq!(*a.borrow_mut(), 2);
+            assert_eq!(*a.lock().unwrap(), 2);
             executor.run(w);
-            assert_eq!(*a.borrow_mut(), 3);
+            assert_eq!(*a.lock().unwrap(), 3);
             executor.run(w);
-            assert_eq!(*a.borrow_mut(), 3);
+            assert_eq!(*a.lock().unwrap(), 3);
         });
     }
 }


### PR DESCRIPTION
This turns the `Executor` into a regular resource. This mean we don't need to rely on a fork of bevy to access `non_send_resource_scope` anymore !
However this also means that the executor must be `Send` + `Sync` which also goes for coroutines them-self.
This make it a bit harder to share values with coroutines, you basically need to wrap everything in an `Arc<Mutex<T>>`, but convenient APIs will be added later on to share values from one coroutine to its children (since ownership and lifetime is easy to reason about in this case). And soon coroutines will be able to interact with the `World` so communication with the outside will be easier and safe.